### PR TITLE
Fix Publix API

### DIFF
--- a/projects/gitlab-client/src/public-api.ts
+++ b/projects/gitlab-client/src/public-api.ts
@@ -3,4 +3,6 @@
  */
 
 export * from './lib/gitlab-client.module';
+export * from './lib/config/gitlab-config.model';
+export * from './lib/shared/gitlab.service';
 export {LabelsByNamePipe} from './lib/services/issues/labels-by-name.pipe';


### PR DESCRIPTION
The import of GitlabConfig and GitlabService is not possible using the public API. We fix this.