### PR TITLE
Fix Circular Dependency between Service and Module

### DIFF
--- a/projects/gitlab-client/src/lib/gitlab-client.module.ts
+++ b/projects/gitlab-client/src/lib/gitlab-client.module.ts
@@ -10,6 +10,7 @@ import {GitlabLabelsService} from './issues/gitlab-labels.service';
 import {IssueImportService} from './issues/issue-import.service';
 import {IssueExportService} from './issues/issue-export.service';
 import {IssueExportModelMapperService} from './issues/issue-export-model-mapper.service';
+import {ProgressService} from './issues/progress/progress.service';
 
 /**
  * Use this injection token to configure a Gitlab connection configuration provider.
@@ -82,7 +83,8 @@ export const GITLAB_CONFIG_PROVIDER = new InjectionToken<() => GitlabConfig>("Gi
     GitlabIssuesService,
     IssueExportModelMapperService,
     IssueImportService,
-    IssueExportService
+    IssueExportService,
+    ProgressService
   ],
   declarations: [
     LabelsByNamePipe

--- a/projects/gitlab-client/src/lib/issues/progress/progress.service.ts
+++ b/projects/gitlab-client/src/lib/issues/progress/progress.service.ts
@@ -1,6 +1,5 @@
 import {Injectable, Optional} from '@angular/core';
 import {BehaviorSubject, defer, Observable, of, tap} from 'rxjs';
-import {GitlabClientModule} from '../../gitlab-client.module';
 
 export abstract class ProgressDialog {
 
@@ -8,7 +7,7 @@ export abstract class ProgressDialog {
 }
 
 @Injectable({
-  providedIn: GitlabClientModule
+  providedIn: null
 })
 export class ProgressService {
 


### PR DESCRIPTION
Error is
```
Uncaught ReferenceError: Cannot access 'GitlabClientModule' before initialization
    at 383 (ueberfuhr-ngx-gitlab-client.mjs:411:142)
    at __webpack_require__ (bootstrap:19:1)
    at 9223 (gitlab-config-dialog.component.html:34:59)
    at __webpack_require__ (bootstrap:19:1)
    at 2250 (page-template.module.ts:19:26)
    at __webpack_require__ (bootstrap:19:1)
    at 5041 (main.js:16:110)
    at __webpack_require__ (bootstrap:19:1)
    at 6747 (app.component.html:3:21)
    at __webpack_require__ (bootstrap:19:1)
```